### PR TITLE
JDP230401-37 - fixed warnings in projects (unused imports, contructors)

### DIFF
--- a/src/main/java/com/kodilla/ecommercee/controller/UserController.java
+++ b/src/main/java/com/kodilla/ecommercee/controller/UserController.java
@@ -10,8 +10,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.List;
-
 @RestController
 @RequestMapping(value = "/v1/shop/users")
 @RequiredArgsConstructor
@@ -35,7 +33,7 @@ public class UserController {
 
     @PutMapping("generateKey")
     public ResponseEntity<UserDto> generateUserActivationKey(@RequestBody UserDto userDto) throws UserNotFoundException {
-        User user = userDbService.generateActivationKey(userDto);
+        User user = userDbService.generateActivationKey(userMapper.mapToUser(userDto));
         User savedUser = userDbService.saveUser(user);
         return ResponseEntity.ok(userMapper.mapToUserDto(savedUser));
     }

--- a/src/main/java/com/kodilla/ecommercee/domain/OrderDetails.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/OrderDetails.java
@@ -2,7 +2,6 @@ package com.kodilla.ecommercee.domain;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;

--- a/src/main/java/com/kodilla/ecommercee/domain/User.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/User.java
@@ -59,4 +59,12 @@ public class User {
         this.isBlocked = isBlocked;
         this.orders = new ArrayList<>();
     }
+
+    public User(Long id, String firstName, String lastName, String login, boolean isBlocked) {
+        this.id = id;
+        this.firstName = firstName;
+        this.lastName = lastName;
+        this.login = login;
+        this.isBlocked = isBlocked;
+    }
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/dto/CartDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/dto/CartDto.java
@@ -4,10 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -18,9 +14,4 @@ public class CartDto {
     private Long id;
     private Long userId;
     private List<ProductDto> products = new ArrayList<>();
-
-    public CartDto(Long id, Long userId) {
-        this.id = id;
-        this.userId = userId;
-    }
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/dto/OrderDetailsDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/dto/OrderDetailsDto.java
@@ -1,9 +1,7 @@
 package com.kodilla.ecommercee.domain.dto;
 
-import com.kodilla.ecommercee.domain.Cart;
 import lombok.AllArgsConstructor;
 import lombok.Data;
-import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
@@ -16,10 +14,4 @@ public class OrderDetailsDto {
     private BigDecimal totalPrice;
     private Long cartId;
     private Long userId;
-
-    public OrderDetailsDto(BigDecimal totalPrice, Long cartId, Long userId) {
-        this.totalPrice = totalPrice;
-        this.cartId = cartId;
-        this.userId = userId;
-    }
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/dto/ProductDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/dto/ProductDto.java
@@ -12,5 +12,4 @@ public class ProductDto {
     private String description;
     private Double price;
     private Long groupId;
-
 }

--- a/src/main/java/com/kodilla/ecommercee/domain/dto/ProductGroupDto.java
+++ b/src/main/java/com/kodilla/ecommercee/domain/dto/ProductGroupDto.java
@@ -1,12 +1,8 @@
 package com.kodilla.ecommercee.domain.dto;
 
-import com.kodilla.ecommercee.domain.Product;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.util.List;
-
 
 @Getter
 @AllArgsConstructor

--- a/src/main/java/com/kodilla/ecommercee/mapper/CartMapper.java
+++ b/src/main/java/com/kodilla/ecommercee/mapper/CartMapper.java
@@ -1,12 +1,9 @@
 package com.kodilla.ecommercee.mapper;
 
 import com.kodilla.ecommercee.domain.Cart;
-import com.kodilla.ecommercee.domain.Product;
 import com.kodilla.ecommercee.domain.dto.CartDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/kodilla/ecommercee/mapper/ProductMapper.java
+++ b/src/main/java/com/kodilla/ecommercee/mapper/ProductMapper.java
@@ -3,9 +3,7 @@ package com.kodilla.ecommercee.mapper;
 import com.kodilla.ecommercee.controller.exceptions.ProductGroupNotFoundException;
 import com.kodilla.ecommercee.domain.Product;
 import com.kodilla.ecommercee.domain.dto.ProductDto;
-import com.kodilla.ecommercee.domain.dto.ProductGroupDto;
 import com.kodilla.ecommercee.repository.ProductGroupRepository;
-import com.kodilla.ecommercee.service.ProductDbService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 

--- a/src/main/java/com/kodilla/ecommercee/mapper/UserMapper.java
+++ b/src/main/java/com/kodilla/ecommercee/mapper/UserMapper.java
@@ -8,24 +8,23 @@ import org.springframework.stereotype.Service;
 public class UserMapper {
 
     public User mapToUser(UserDto userDto) {
-        User user = new User();
-        user.setId(userDto.getId());
-        user.setFirstName(userDto.getFirstName());
-        user.setLastName(userDto.getLastName());
-        user.setBlocked(userDto.isBlocked());
-        user.setActivationKey(userDto.getActivationKey());
-        user.setLogin(userDto.getLogin());
-        return user;
+        return new User(
+                userDto.getId(),
+                userDto.getFirstName(),
+                userDto.getLastName(),
+                userDto.getLogin(),
+                userDto.isBlocked()
+        );
     }
 
     public UserDto mapToUserDto(User user) {
-        UserDto userDto = new UserDto();
-        userDto.setId(user.getId());
-        userDto.setFirstName(user.getFirstName());
-        userDto.setLastName(user.getLastName());
-        userDto.setBlocked(user.isBlocked());
-        userDto.setActivationKey(user.getActivationKey());
-        userDto.setLogin(user.getLogin());
-        return userDto;
+        return new UserDto(
+                user.getId(),
+                user.getFirstName(),
+                user.getLastName(),
+                user.isBlocked(),
+                user.getActivationKey(),
+                user.getLogin()
+        );
     }
 }

--- a/src/main/java/com/kodilla/ecommercee/service/CartDbService.java
+++ b/src/main/java/com/kodilla/ecommercee/service/CartDbService.java
@@ -8,13 +8,10 @@ import com.kodilla.ecommercee.domain.OrderDetails;
 import com.kodilla.ecommercee.domain.Product;
 import com.kodilla.ecommercee.domain.User;
 import com.kodilla.ecommercee.repository.CartRepository;
-import com.kodilla.ecommercee.repository.OrderDetailsRepository;
 import com.kodilla.ecommercee.repository.ProductRepository;
 import com.kodilla.ecommercee.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-
-import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/kodilla/ecommercee/service/ProductDbService.java
+++ b/src/main/java/com/kodilla/ecommercee/service/ProductDbService.java
@@ -1,16 +1,12 @@
 package com.kodilla.ecommercee.service;
 
-import com.kodilla.ecommercee.controller.exceptions.ProductGroupNotFoundException;
 import com.kodilla.ecommercee.controller.exceptions.ProductNotFoundException;
 import com.kodilla.ecommercee.domain.Product;
-import com.kodilla.ecommercee.domain.ProductGroup;
-import com.kodilla.ecommercee.repository.ProductGroupRepository;
 import com.kodilla.ecommercee.repository.ProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor

--- a/src/main/java/com/kodilla/ecommercee/service/UserDbService.java
+++ b/src/main/java/com/kodilla/ecommercee/service/UserDbService.java
@@ -20,28 +20,25 @@ public class UserDbService {
         return userRepository.save(user);
     }
 
-    public User generateActivationKey(final UserDto userDto) throws UserNotFoundException {
-        User user = userRepository.findById(userDto.getId()).orElseThrow(UserNotFoundException::new);
-        if (!user.getLogin().equals(userDto.getLogin())) {
+    public User generateActivationKey(final User user) throws UserNotFoundException {
+        User generatesUser = userRepository.findById(user.getId()).orElseThrow(UserNotFoundException::new);
+        if (!generatesUser.getLogin().equals(user.getLogin())) {
             throw new UserNotFoundException();
         }
+
         LocalDateTime activationTime = LocalDateTime.now().plusHours(1);
         UUID activationKey = UUID.randomUUID();
-        user.setActivationKey(activationKey);
-        user.setActivationKeyExpiration(activationTime);
-        userRepository.save(user);
+        generatesUser.setActivationKey(activationKey);
+        generatesUser.setActivationKeyExpiration(activationTime);
 
-        return user;
+        return userRepository.save(generatesUser);
     }
 
     public User blockUser(Long userId) throws UserNotFoundException {
         User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
-        if (user != null) {
-            user.setBlocked(true);
-            user.setActivationKey(null);
-            user.setActivationKeyExpiration(null);
-            userRepository.save(user);
-        }
-        return user;
+        user.setBlocked(true);
+        user.setActivationKey(null);
+        user.setActivationKeyExpiration(null);
+        return userRepository.save(user);
     }
 }

--- a/src/test/java/com/kodilla/ecommercee/repository/CartGroupRepositoryTests.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/CartGroupRepositoryTests.java
@@ -17,7 +17,7 @@ import static org.junit.Assert.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest
-public class CartGroupRepositoryTestSuite {
+public class CartGroupRepositoryTests {
 
     @Autowired
     private CartRepository cartGroupRepository;

--- a/src/test/java/com/kodilla/ecommercee/repository/OrderDetailsRepositoryTests.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/OrderDetailsRepositoryTests.java
@@ -73,6 +73,7 @@ public class OrderDetailsRepositoryTests {
         orderDetailsRepository.save(orderDetails);
 
         //Then
+        assertTrue(orderDetailsRepository.findById(orderDetails.getId()).isPresent());
         assertEquals(2,orderDetailsRepository.findById(orderDetails.getId()).get().getCart().getProductList().size());
 
         //Clean up

--- a/src/test/java/com/kodilla/ecommercee/repository/ProductGroupRepositoryTests.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/ProductGroupRepositoryTests.java
@@ -49,7 +49,7 @@ public class ProductGroupRepositoryTests {
         //When
         productGroupRepository.save(productGroup1);
         productGroupRepository.save(productGroup2);
-        List<ProductGroup> productGroupList = (List<ProductGroup>) productGroupRepository.findAll();
+        List<ProductGroup> productGroupList = productGroupRepository.findAll();
 
         //Then
         assertEquals(2, productGroupList.size());

--- a/src/test/java/com/kodilla/ecommercee/repository/UserRepositoryTests.java
+++ b/src/test/java/com/kodilla/ecommercee/repository/UserRepositoryTests.java
@@ -92,6 +92,7 @@ public class UserRepositoryTests {
         user.getOrders().add(orderDetails2);
 
         //Then
+        assertTrue(userRepository.findById(user.getId()).isPresent());
         assertEquals(2,userRepository.findById(user.getId()).get().getOrders().size());
 
         //Clean up


### PR DESCRIPTION
Fixed warnings in projects mainly:
- unused impots in multiple classes
- unsued contructors in mulitple classes
- unchaed ifPresent() in multiple test suites

Minor naming convention changes - delelteCart -> deleteFromCart and ...TestSuite -> ..Tests.

Changes to UserDbService - inline returns and remove unnecessary != null check.

Changes to UserMapper - one constructor instead of multiple setters and inline returns.